### PR TITLE
Update dependabot.yaml

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -22,6 +22,3 @@ updates:
     schedule:
       interval: monthly
     open-pull-requests-limit: 5
-
-# Enable automatic security updates
-security_updates: true


### PR DESCRIPTION
The old version contains property ["security_updates"] which is outside of the schema when none are allowed