### PR TITLE
Update dependencies and spaCy model loading

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,6 @@ weave = "^0.51.39"
 mlflow = "^2.21.1"
 poetry = "^2.1.1"
 spacy = ">=3.8.11,<3.9.0"
-en-core-web-sm = {url = "https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl"}
 litellm = {version = ">=1.17.0,<1.60.0"}
 transformers = ">=4.30.0,<4.46.0"
 torch = "^2.10.0"

--- a/src/utils/ner_tool.py
+++ b/src/utils/ner_tool.py
@@ -25,6 +25,7 @@ from openai import OpenAI
 from transformers import pipeline, AutoModelForTokenClassification, AutoTokenizer
 from concurrent.futures import ThreadPoolExecutor, as_completed
 import spacy
+from spacy.cli import download
 import torch
 import logging
 
@@ -122,10 +123,9 @@ def get_spacy_model():
         try:
             _spacy_nlp = spacy.load(SPACY_MODEL)
         except OSError:
-            raise OSError(
-                f"spaCy model '{SPACY_MODEL}' is not installed. "
-                f"Run 'poetry install' or 'uv sync' to install project dependencies."
-            ) from None
+            logger.info(f"Downloading spaCy model: {SPACY_MODEL}")
+            download(SPACY_MODEL)
+            _spacy_nlp = spacy.load(SPACY_MODEL)
     return _spacy_nlp
 
 


### PR DESCRIPTION
**Current Changes**
pyproject.toml: narrow litellm version upper bound from <1.80.0 to <1.60.0 to avoid a regression where newer versions accidentally import litellm.proxy.proxy_server, pulling in proxy-only dependencies (apscheduler) even when the proxy is not used.


**Reverted Changes to Original PR- Outdated:** 
- ner_tool.py: Remove automatic spaCy model download at runtime; raise an explicit error if the model is not installed, prompting the user to install it manually.
- pyproject.toml: Add en_core_web_sm as a direct dependency via URL so the model is installed at project setup time rather than downloaded at runtime via spacy.cli.download(), which uses pip internally and fails in non-pip environments (e.g. uv)