### PR TITLE
Fix StructSenseFlow.__init__ parameter name: input_source -> source

### DIFF
--- a/src/structsense/app.py
+++ b/src/structsense/app.py
@@ -245,7 +245,7 @@ class StructSenseFlow:
             task_config: Union[str, dict],
             embedder_config: Union[str, dict],
             source_text: Optional[str] = None,
-            input_source: Optional[Union[str, dict]] = None,
+            source: Optional[Union[str, dict]] = None,
             enable_human_feedback: bool = False,
             enable_chunking: bool = False,
             knowledge_config: Optional[Union[str, dict]] = None,


### PR DESCRIPTION
The parameter was renamed to input_source in the signature but the method body still referenced source, causing a TypeError when called from the CLI.

```
  File "/Users/pujatrivedi/Desktop/MIT/structsense/src/structsense/cli.py", line 102, in extract
    flow = StructSenseFlow(
           ^^^^^^^^^^^^^^^^
TypeError: StructSenseFlow.__init__() got an unexpected keyword argument 'source'
```