### PR TITLE
Update test parameterization for task_type

### DIFF
--- a/src/tests/task_detection_test.py
+++ b/src/tests/task_detection_test.py
@@ -51,7 +51,7 @@ def make_flow(agent_config=None, task_config=None):
     )
 
 
-@pytest.mark.parametrize("task_type", ["ner", "extraction", "keyphrase_extraction"])
+@pytest.mark.parametrize("task_type", ["ner", "extraction"])
 def test_task_type_from_config(task_type):
     """task_type is explicitly set in agent_config — returned directly without LLM or heuristic."""
     task_config = {


### PR DESCRIPTION
Removed 'keyphrase_extraction' from task_type parameterization in tests based on the updated code.